### PR TITLE
Bug fix for AvatarView child UriImageSource dimensions not being correctly applied.

### DIFF
--- a/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
@@ -364,6 +364,8 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 #endif
 			double imageWidth = Width - (StrokeThickness * 2) - Padding.Left - Padding.Right;
 			double imageHeight = Height - (StrokeThickness * 2) - Padding.Top - Padding.Bottom;
+			avatarImage.WidthRequest = imageWidth;
+			avatarImage.HeightRequest = imageHeight;
 
 			if (!OperatingSystem.IsIOS() && !OperatingSystem.IsMacCatalyst() && !OperatingSystem.IsMacOS())
 			{


### PR DESCRIPTION
Any dimension restrictions, such as Padding or BorderWidth which should in effect reduce the dimensions of the contained child element (in this instance the image).